### PR TITLE
BugFix | Adding missing Action in Scanner Role PolicyDocument

### DIFF
--- a/Asia-1/aqua-cspm-onboarding.yaml
+++ b/Asia-1/aqua-cspm-onboarding.yaml
@@ -365,6 +365,7 @@
                 - backup:DescribeRegionSettings
                 - backup:getBackupVaultNotifications
                 - backup:ListBackupPlans
+                - backup:GetBackupPlan
                 - backup:GetBackupVaultAccessPolicy
                 - dlm:GetLifecyclePolicies
                 - glue:GetSecurityConfigurations

--- a/Asia-2/aqua-cspm-onboarding.yaml
+++ b/Asia-2/aqua-cspm-onboarding.yaml
@@ -361,6 +361,7 @@
                 - databrew:ListJobs
                 - managedblockchain:ListNetworks
                 - connect:ListInstances
+                - backup:GetBackupPlan
                 - backup:ListBackupVaults
                 - backup:DescribeRegionSettings
                 - backup:getBackupVaultNotifications

--- a/Europe/aqua-cspm-onboarding.yaml
+++ b/Europe/aqua-cspm-onboarding.yaml
@@ -365,6 +365,7 @@ Resources:
             - backup:DescribeRegionSettings
             - backup:getBackupVaultNotifications
             - backup:ListBackupPlans
+            - backup:GetBackupPlan
             - backup:GetBackupVaultAccessPolicy
             - dlm:GetLifecyclePolicies
             - glue:GetSecurityConfigurations

--- a/US/aqua-cspm-onboarding.yaml
+++ b/US/aqua-cspm-onboarding.yaml
@@ -365,6 +365,7 @@ Resources:
             - backup:DescribeRegionSettings
             - backup:getBackupVaultNotifications
             - backup:ListBackupPlans
+            - backup:GetBackupPlan
             - backup:GetBackupVaultAccessPolicy
             - dlm:GetLifecyclePolicies
             - glue:GetSecurityConfigurations


### PR DESCRIPTION
The policy attached to the scanner role is missing the action backup:GetBackupPlan as a result of which the plugin 'AWS Backup Compliant Lifecycle Configured' returns an unknown result with the message that the scanner does not have permission to perform this API call.