### PR TITLE
Add Missing Actions

### DIFF
--- a/Asia-1/aqua-cspm-onboarding.yaml
+++ b/Asia-1/aqua-cspm-onboarding.yaml
@@ -331,6 +331,7 @@
                 - logs:DescribeLogGroups
                 - logs:DescribeMetricFilters
                 - config:getComplianceDetailsByConfigRule
+                - elasticmapreduce:ListInstanceGroups
                 - elastictranscoder:ListPipelines
                 - elasticfilesystem:DescribeFileSystems
                 - servicequotas:ListServiceQuotas
@@ -353,6 +354,7 @@
                 - memorydb:DescribeClusters
                 - kafka:ListClusters
                 - apprunner:ListServices
+                - apprunner:DescribeService
                 - finspace:ListEnvironments
                 - healthlake:ListFHIRDatastores
                 - codeartifact:ListDomains
@@ -365,6 +367,7 @@
                 - backup:DescribeRegionSettings
                 - backup:getBackupVaultNotifications
                 - backup:ListBackupPlans
+                - backup:GetBackupPlan
                 - backup:GetBackupVaultAccessPolicy
                 - dlm:GetLifecyclePolicies
                 - glue:GetSecurityConfigurations

--- a/Asia-2/aqua-cspm-onboarding.yaml
+++ b/Asia-2/aqua-cspm-onboarding.yaml
@@ -331,6 +331,7 @@
                 - logs:DescribeLogGroups
                 - logs:DescribeMetricFilters
                 - config:getComplianceDetailsByConfigRule
+                - elasticmapreduce:ListInstanceGroups
                 - elastictranscoder:ListPipelines
                 - elasticfilesystem:DescribeFileSystems
                 - servicequotas:ListServiceQuotas
@@ -353,6 +354,7 @@
                 - memorydb:DescribeClusters
                 - kafka:ListClusters
                 - apprunner:ListServices
+                - apprunner:DescribeService
                 - finspace:ListEnvironments
                 - healthlake:ListFHIRDatastores
                 - codeartifact:ListDomains
@@ -365,6 +367,7 @@
                 - backup:DescribeRegionSettings
                 - backup:getBackupVaultNotifications
                 - backup:ListBackupPlans
+                - backup:GetBackupPlan
                 - backup:GetBackupVaultAccessPolicy
                 - dlm:GetLifecyclePolicies
                 - glue:GetSecurityConfigurations

--- a/Europe/aqua-cspm-onboarding.yaml
+++ b/Europe/aqua-cspm-onboarding.yaml
@@ -331,6 +331,7 @@ Resources:
             - logs:DescribeLogGroups
             - logs:DescribeMetricFilters
             - config:getComplianceDetailsByConfigRule
+            - elasticmapreduce:ListInstanceGroups
             - elastictranscoder:ListPipelines
             - elasticfilesystem:DescribeFileSystems
             - servicequotas:ListServiceQuotas
@@ -353,6 +354,7 @@ Resources:
             - memorydb:DescribeClusters
             - kafka:ListClusters
             - apprunner:ListServices
+            - apprunner:DescribeService
             - finspace:ListEnvironments
             - healthlake:ListFHIRDatastores
             - codeartifact:ListDomains
@@ -365,6 +367,7 @@ Resources:
             - backup:DescribeRegionSettings
             - backup:getBackupVaultNotifications
             - backup:ListBackupPlans
+            - backup:GetBackupPlan
             - backup:GetBackupVaultAccessPolicy
             - dlm:GetLifecyclePolicies
             - glue:GetSecurityConfigurations

--- a/US/aqua-cspm-onboarding.yaml
+++ b/US/aqua-cspm-onboarding.yaml
@@ -331,6 +331,7 @@ Resources:
             - logs:DescribeLogGroups
             - logs:DescribeMetricFilters
             - config:getComplianceDetailsByConfigRule
+            - elasticmapreduce:ListInstanceGroups
             - elastictranscoder:ListPipelines
             - elasticfilesystem:DescribeFileSystems
             - servicequotas:ListServiceQuotas
@@ -353,6 +354,7 @@ Resources:
             - memorydb:DescribeClusters
             - kafka:ListClusters
             - apprunner:ListServices
+            - apprunner:DescribeService
             - finspace:ListEnvironments
             - healthlake:ListFHIRDatastores
             - codeartifact:ListDomains
@@ -365,6 +367,7 @@ Resources:
             - backup:DescribeRegionSettings
             - backup:getBackupVaultNotifications
             - backup:ListBackupPlans
+            - backup:GetBackupPlan
             - backup:GetBackupVaultAccessPolicy
             - dlm:GetLifecyclePolicies
             - glue:GetSecurityConfigurations


### PR DESCRIPTION
In this change we are adding 3 missing actions that are needed by the AWS plugins - Service Encrypted, EMR Instance Counts and AWS Backup Compliant Lifecycle configured. Without these permissions, we will get an Unknown Result for each of these plugins.