### PR TITLE
Typo in supplemental policy for action ssm:describeSession

### DIFF
--- a/Europe/aqua-cspm-onboarding.yaml
+++ b/Europe/aqua-cspm-onboarding.yaml
@@ -371,7 +371,7 @@ Resources:
             - backup:GetBackupVaultAccessPolicy
             - dlm:GetLifecyclePolicies
             - glue:GetSecurityConfigurations
-            - ssm:describeSessions
+            - ssm:DescribeSessions
             - ssm:GetServiceSetting
             - ecr:DescribeRegistry
             - ecr-public:DescribeRegistries


### PR DESCRIPTION
Should be capital D 

https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeSessions.html