### PR TITLE
Fix| Update Cloudsploit Lambda Name in EU,Asia-1 and Asia-2 Regions

### DIFF
--- a/Asia-1/aqua-cspm-onboarding.yaml
+++ b/Asia-1/aqua-cspm-onboarding.yaml
@@ -279,7 +279,7 @@
             Statement:
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/uwbwh-lambda-cloudsploit-api
+                AWS: arn:aws:iam::057012691312:role/uwbwh-cloudsploit-api
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -288,7 +288,7 @@
                   aws:SourceIp: 13.215.18.141/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/uwbwh-lambda-cloudsploit-collector
+                AWS: arn:aws:iam::057012691312:role/uwbwh-cloudsploit-collector
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -297,7 +297,7 @@
                   aws:SourceIp: 13.215.18.141/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/uwbwh-lambda-cloudsploit-remediator
+                AWS: arn:aws:iam::057012691312:role/uwbwh-cloudsploit-remediator
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -306,7 +306,7 @@
                   aws:SourceIp: 13.215.18.141/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/uwbwh-lambda-cloudsploit-tasks
+                AWS: arn:aws:iam::057012691312:role/uwbwh-cloudsploit-tasks
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:

--- a/Asia-2/aqua-cspm-onboarding.yaml
+++ b/Asia-2/aqua-cspm-onboarding.yaml
@@ -279,7 +279,7 @@
             Statement:
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/gtnpr-lambda-cloudsploit-api
+                AWS: arn:aws:iam::057012691312:role/gtnpr-cloudsploit-api
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -288,7 +288,7 @@
                   aws:SourceIp: 52.78.161.45/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/gtnpr-lambda-cloudsploit-collector
+                AWS: arn:aws:iam::057012691312:role/gtnpr-cloudsploit-collector
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -297,7 +297,7 @@
                   aws:SourceIp: 52.78.161.45/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/gtnpr-lambda-cloudsploit-remediator
+                AWS: arn:aws:iam::057012691312:role/gtnpr-cloudsploit-remediator
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:
@@ -306,7 +306,7 @@
                   aws:SourceIp: 52.78.161.45/32
             - Effect: Allow
               Principal:
-                AWS: arn:aws:iam::057012691312:role/gtnpr-lambda-cloudsploit-tasks
+                AWS: arn:aws:iam::057012691312:role/gtnpr-cloudsploit-tasks
               Action: 'sts:AssumeRole'
               Condition:
                 StringEquals:

--- a/Europe/aqua-cspm-onboarding.yaml
+++ b/Europe/aqua-cspm-onboarding.yaml
@@ -279,7 +279,7 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            AWS: arn:aws:iam::057012691312:role/hgwbs-lambda-cloudsploit-api
+            AWS: arn:aws:iam::057012691312:role/hgwbs-cloudsploit-api
           Action: 'sts:AssumeRole'
           Condition:
             StringEquals:
@@ -288,7 +288,7 @@ Resources:
               aws:SourceIp: 18.198.57.107/32
         - Effect: Allow
           Principal:
-            AWS: arn:aws:iam::057012691312:role/hgwbs-lambda-cloudsploit-collector
+            AWS: arn:aws:iam::057012691312:role/hgwbs-cloudsploit-collector
           Action: 'sts:AssumeRole'
           Condition:
             StringEquals:
@@ -297,7 +297,7 @@ Resources:
               aws:SourceIp: 18.198.57.107/32
         - Effect: Allow
           Principal:
-            AWS: arn:aws:iam::057012691312:role/hgwbs-lambda-cloudsploit-remediator
+            AWS: arn:aws:iam::057012691312:role/hgwbs-cloudsploit-remediator
           Action: 'sts:AssumeRole'
           Condition:
             StringEquals:
@@ -306,7 +306,7 @@ Resources:
               aws:SourceIp: 18.198.57.107/32
         - Effect: Allow
           Principal:
-            AWS: arn:aws:iam::057012691312:role/hgwbs-lambda-cloudsploit-tasks
+            AWS: arn:aws:iam::057012691312:role/hgwbs-cloudsploit-tasks
           Action: 'sts:AssumeRole'
           Condition:
             StringEquals:


### PR DESCRIPTION
The CLoudsplloit Lambda names in the Asia-1,Asia-2 and the EU regions no longer have the word lambda in them. As a result when someone onboards using this stack, the Lambdas fail to assume the role.